### PR TITLE
Fix macOS process detection

### DIFF
--- a/adb_utils.py
+++ b/adb_utils.py
@@ -8,9 +8,9 @@ from PIL import Image
 
 
 def ensure_app_running():
-    """Ensure the macOS process 'The Tower' is running."""
+    """Ensure the game process is running on macOS."""
     for proc in psutil.process_iter(['name']):
-        if proc.info['name'] == 'The Tower':
+        if proc.info['name'] in ('The Tower', 'TheTower'):
             return
     raise SystemExit("[FATAL] 'The Tower' process not found")
 

--- a/tower_bot_core.py
+++ b/tower_bot_core.py
@@ -134,9 +134,9 @@ if not TESS_PATH:
 pytesseract.pytesseract.tesseract_cmd = TESS_PATH
 
 def ensure_app_running():
-    """Ensure the macOS process 'The Tower' is running."""
+    """Ensure the game process is running on macOS."""
     for proc in psutil.process_iter(['name']):
-        if proc.info['name'] == 'The Tower':
+        if proc.info['name'] in ('The Tower', 'TheTower'):
             return
     raise SystemExit("[FATAL] 'The Tower' process not found")
 


### PR DESCRIPTION
## Summary
- update `ensure_app_running` to detect `TheTower` process name

## Testing
- `python3 -m py_compile adb_utils.py tower_bot_core.py engine.py tower_bot_gui.py ocr_utils.py debounce.py config.py run_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6868896dc928832c861290976eefc9a1