### PR TITLE
Improve Tower process detection

### DIFF
--- a/adb_utils.py
+++ b/adb_utils.py
@@ -21,8 +21,11 @@ def ensure_app_running():
     fatal error, simply return False when the process is missing so callers can
     decide how to proceed.
     """
-    for proc in psutil.process_iter(['name']):
-        if proc.info['name'] in ('The Tower', 'TheTower'):
+    for proc in psutil.process_iter(['name', 'exe', 'cmdline']):
+        name = (proc.info.get('name') or '').lower()
+        exe = (proc.info.get('exe') or '').lower()
+        cmd = ' '.join(proc.info.get('cmdline') or []).lower()
+        if 'tower' in name or 'tower' in exe or 'tower' in cmd:
             return True
     return False
 

--- a/tower_bot_core.py
+++ b/tower_bot_core.py
@@ -146,8 +146,11 @@ def ensure_app_running():
     Returns ``True`` when found, ``False`` otherwise. The previous behaviour was
     to terminate the program which made testing difficult.
     """
-    for proc in psutil.process_iter(['name']):
-        if proc.info['name'] in ('The Tower', 'TheTower'):
+    for proc in psutil.process_iter(['name', 'exe', 'cmdline']):
+        name = (proc.info.get('name') or '').lower()
+        exe = (proc.info.get('exe') or '').lower()
+        cmd = ' '.join(proc.info.get('cmdline') or []).lower()
+        if 'tower' in name or 'tower' in exe or 'tower' in cmd:
             return True
     return False
 


### PR DESCRIPTION
## Summary
- broaden search for The Tower process by checking executable and command line

## Testing
- `python -m py_compile adb_utils.py engine.py tower_bot_core.py ocr_utils.py debounce.py run_bot.py tower_bot_gui.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686891419b3c832ca371b63d820c295d