### PR TITLE
Fix coordinates and add hotkey

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -1,6 +1,13 @@
 # run_bot.py
 
 import time
+try:
+    import keyboard  # type: ignore
+    _HAS_KEYBOARD = True
+except Exception:
+    keyboard = None
+    _HAS_KEYBOARD = False
+
 from engine import BotConfig, TowerBot, load_regions
 
 if __name__ == "__main__":
@@ -8,9 +15,15 @@ if __name__ == "__main__":
     load_regions(cfg)
     bot = TowerBot(cfg)
     bot.start()
-    try:
-        # keep the main thread alive
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        bot.stop()
+
+    if _HAS_KEYBOARD:
+        print("Press Ctrl+Alt+S to stop")
+        keyboard.add_hotkey("ctrl+alt+s", bot.stop)
+        keyboard.wait("ctrl+alt+s")
+    else:
+        print("Press Ctrl+C to stop")
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            bot.stop()

--- a/tower_bot_gui.py
+++ b/tower_bot_gui.py
@@ -41,6 +41,8 @@ class TowerBotGUI(tk.Tk):
 
         self._build_gui()
         self._update_wave_label()
+        # Global hotkey to stop/start the bot
+        self.bind_all('<Control-Alt-s>', self._hotkey_toggle)
 
     def _build_gui(self):
         pad = {'padx': 5, 'pady': 2}
@@ -205,6 +207,10 @@ class TowerBotGUI(tk.Tk):
             self.bot.stop()
             self.cfg.running = False
             self.btn.config(text="Start")
+
+    def _hotkey_toggle(self, event=None):
+        """Toggle the bot via Ctrl+Alt+S."""
+        self._toggle()
 
     def _on_close(self):
         if self.cfg.running and not messagebox.askyesno("Quit", "Bot running. Quit anyway?"):


### PR DESCRIPTION
## Summary
- adjust screen scale handling for macOS Retina/HiDPI displays
- scale tap coordinates so captured points align with actual clicks
- allow running `run_bot.py` with Ctrl+Alt+S hotkey to stop
- add the same Ctrl+Alt+S toggle to the GUI

## Testing
- `python3 -m py_compile adb_utils.py run_bot.py tower_bot_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686898409014832ca9108ccd6d4818dc